### PR TITLE
Address issue #4

### DIFF
--- a/Transformer_walkthrough.ipynb
+++ b/Transformer_walkthrough.ipynb
@@ -649,7 +649,7 @@
     {
       "cell_type": "code",
       "source": [
-        "x = x.transpose(1, 2).contiguous().view(num_batches, -1, h * (d_embed // num_heads))\n",
+        "x = x.transpose(1, 2).contiguous().view(num_batches, -1, num_heads * (d_embed // num_heads))\n",
         "print(x.size())"
       ],
       "metadata": {


### PR DESCRIPTION
There is a rogue 'h' where a 'num_heads' should be in the first unfold.  The output is correct, but when the notebook is rerun the variable h is undefined, leading to subsequent failures.

Replacing the 'h' causes the notebook to run in agreement with the code walkthrough.